### PR TITLE
Fix(page): Get network id  in admin page

### DIFF
--- a/src/components/AdminContainer.js
+++ b/src/components/AdminContainer.js
@@ -87,7 +87,7 @@ class AdminContainer extends Component {
   }
 
   componentDidMount() {
-    if (this.props.networkId == null) {
+    if (!this.props.networkId) {
       this.props.updateNetworkId();
       this.props.loadAdminAddress();
     }

--- a/src/components/AdminContainer.js
+++ b/src/components/AdminContainer.js
@@ -86,6 +86,11 @@ class AdminContainer extends Component {
     };
   }
 
+  componentDidMount() {
+    this.props.updateNetworkId();
+    this.props.loadAdminAddress();
+  }
+
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.storeAddress !== this.state.localStoreAddress) {
@@ -279,5 +284,6 @@ AdminContainer.propTypes = {
   revokingCertificate: PropTypes.bool,
   revokedTx: PropTypes.string,
   revokeCertificate: PropTypes.func,
+  network: PropTypes.string,
   networkId: PropTypes.number
 };

--- a/src/components/AdminContainer.js
+++ b/src/components/AdminContainer.js
@@ -87,8 +87,11 @@ class AdminContainer extends Component {
   }
 
   componentDidMount() {
-    this.props.updateNetworkId();
-    this.props.loadAdminAddress();
+    const { networkId, updateNetworkId, loadAdminAddress } = this.props;
+    if (networkId == null) {
+      updateNetworkId();
+      loadAdminAddress();
+    }
   }
 
   // eslint-disable-next-line camelcase

--- a/src/components/AdminContainer.js
+++ b/src/components/AdminContainer.js
@@ -87,10 +87,9 @@ class AdminContainer extends Component {
   }
 
   componentDidMount() {
-    const { networkId, updateNetworkId, loadAdminAddress } = this.props;
-    if (networkId == null) {
-      updateNetworkId();
-      loadAdminAddress();
+    if (this.props.networkId == null) {
+      this.props.updateNetworkId();
+      this.props.loadAdminAddress();
     }
   }
 

--- a/src/components/AdminContainer.js
+++ b/src/components/AdminContainer.js
@@ -284,6 +284,5 @@ AdminContainer.propTypes = {
   revokingCertificate: PropTypes.bool,
   revokedTx: PropTypes.string,
   revokeCertificate: PropTypes.func,
-  network: PropTypes.string,
   networkId: PropTypes.number
 };

--- a/src/components/ErrorPage.js
+++ b/src/components/ErrorPage.js
@@ -2,6 +2,8 @@ import { Component } from "react";
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
 import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import { loadAdminAddress } from "../reducers/admin";
 import { OrangeOutlineButton, OrangeButton } from "./UI/Button";
 import Panel from "./UI/Panel";
 import WalletProviderSelector from "./WalletProviderSelector";
@@ -17,7 +19,6 @@ const walletError = css`
 class ErrorPage extends Component {
   constructor(props) {
     super(props);
-    this.refreshPage = this.refreshPage.bind(this);
     this.toggleWalletProviderSelector = this.toggleWalletProviderSelector.bind(
       this
     );
@@ -25,11 +26,6 @@ class ErrorPage extends Component {
     this.state = {
       showWalletProviderSelector: false
     };
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  refreshPage() {
-    window.location.reload();
   }
 
   toggleWalletProviderSelector() {
@@ -64,7 +60,10 @@ class ErrorPage extends Component {
               >
                 Change Wallet Provider
               </OrangeButton>
-              <OrangeOutlineButton variant="pill" onClick={this.refreshPage}>
+              <OrangeOutlineButton
+                variant="pill"
+                onClick={() => this.props.loadAdminAddress()}
+              >
                 Retry
               </OrangeOutlineButton>
             </div>
@@ -80,12 +79,20 @@ class ErrorPage extends Component {
   }
 }
 
-export default ErrorPage;
+const mapDispatchToProps = dispatch => ({
+  loadAdminAddress: payload => dispatch(loadAdminAddress(payload))
+});
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(ErrorPage);
 
 ErrorPage.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
   ]),
-  rest: PropTypes.object
+  rest: PropTypes.object,
+  loadAdminAddress: PropTypes.func
 };


### PR DESCRIPTION
FIxed bugged where the page does not get the network ID when the user directly accesses the deploy page.